### PR TITLE
Fix scroll to bottom on My Mods list

### DIFF
--- a/bin/gui/css/main.css
+++ b/bin/gui/css/main.css
@@ -279,7 +279,7 @@ p {
 }
 
 .scroller-small {
-	height: calc(100vh - 118px);
+	height: calc(100vh - 118px - 114px);
 	overflow-y: auto;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "bin/connection-manager.js": "032d0e5c021ffc3d0dcc5c3e33326239be010a19c4ac710ef0e48e94b5235d94",
     "bin/gui/assets/icon.ico": "eddf1fe34c998df2b607cd36f69334d9890a7f150917b0aa4d1fb6db891aa5f0",
     "bin/gui/assets/tb.gif": "3bf32d7df587cb85807341232122a26c5eeb9a2b7840eb12a19b45d1622bae69",
-    "bin/gui/css/main.css": "546afe50ae50aa7e8b9d4850bcb369f7aae1f9a663390d737df8794475c0c5d6",
+    "bin/gui/css/main.css": "4acc9a3e65855c505c1915c804b41365f8f314099c459f7eb9f3ade6ec4f3f0e",
     "bin/gui/css/materialdesignicons.min.css": "0e68f7525a9f5ed88a0371740750a9615a0703d45c169891d3b8dfabbebc0057",
     "bin/gui/css/microtip.css": "d835d52cc7e96e6d00e85cf39e36e066d8e51360cc3a0407de429269020c0fba",
     "bin/gui/css/splash.css": "c0418636deb0e80848ac508724a430f013a93a0f686c8d3b259d3b2c865e3d5d",


### PR DESCRIPTION
Unsupported mods warning pushed the scroller below the window border, causing last mods to not be accessible.